### PR TITLE
README: the 'master' of this repo works with 'latest' KEDA image

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A simple docker container that will receive messages from a RabbitMQ queue and s
 ## Pre-requisites
 
 * Kubernetes cluster
-* [KEDA installed](https://github.com/kedacore/keda#setup) on the cluster
+* [KEDA installed](https://github.com/kedacore/keda#setup) on the cluster. Note that the `master` branch of this repo works with the `latest` image of KEDA's container. If you are experimenting with a KEDA image that is built based on `master` (not `latest`) then there is a possibility this example will not work properly.
 
 ## Setup
 


### PR DESCRIPTION
Based on the issue #2, I am proposing to put a note in README to tell people that this sample might not work if they are using an image of KEDA that is NOT `latest`.