### PR TITLE
Add Helm 3 install instructions and note for Kind

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,9 @@ helm install rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD st
 ```
 ⚠️ Some distributions of Kubernetes (like [Kind](https://kind.sigs.k8s.io/)) require that you add `volumePermissions.enabled=true` to the parameters in the `--set` option:
 
-```--set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true```
-
+```cli
+--set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true
+```
 
 ⚠️ Be sure to wait until the deployment has completed before continuing.  
 

--- a/README.md
+++ b/README.md
@@ -23,9 +23,13 @@ cd sample-go-rabbitmq
 #### [Install Helm](https://helm.sh/docs/using_helm/)
 
 #### Install RabbitMQ via Helm
-
+Helm 2
 ```cli
 helm install --name rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD stable/rabbitmq
+```
+Helm 3
+```
+helm install rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD stable/rabbitmq
 ```
 
 ⚠️ Be sure to wait until the deployment has completed before continuing.  

--- a/README.md
+++ b/README.md
@@ -25,11 +25,16 @@ cd sample-go-rabbitmq
 #### Install RabbitMQ via Helm
 Helm 2
 ```cli
-helm install --name rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true stable/rabbitmq
+helm install --name rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD stable/rabbitmq
 ```
 Helm 3
 ```
-helm install rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true stable/rabbitmq
+helm install rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD stable/rabbitmq
+```
+⚠️ Some distributions of Kubernetes (like [Kind](https://kind.sigs.k8s.io/) require that you add `volumePermissions.enabled=true` to the parameters in the `--set` flag:
+
+```
+--set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true
 ```
 
 ⚠️ Be sure to wait until the deployment has completed before continuing.  

--- a/README.md
+++ b/README.md
@@ -31,11 +31,8 @@ Helm 3
 ```
 helm install rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD stable/rabbitmq
 ```
-⚠️ Some distributions of Kubernetes (like [Kind](https://kind.sigs.k8s.io/) require that you add `volumePermissions.enabled=true` to the parameters in the `--set` flag:
+⚠️ Some distributions of Kubernetes (like [Kind](https://kind.sigs.k8s.io/)) require that you add `volumePermissions.enabled=true` to the parameters in the `--set` option (e.g. `--set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true`)
 
-```
---set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true
-```
 
 ⚠️ Be sure to wait until the deployment has completed before continuing.  
 

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ cd sample-go-rabbitmq
 #### Install RabbitMQ via Helm
 Helm 2
 ```cli
-helm install --name rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD stable/rabbitmq
+helm install --name rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true stable/rabbitmq
 ```
 Helm 3
 ```
-helm install rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD stable/rabbitmq
+helm install rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true stable/rabbitmq
 ```
 
 ⚠️ Be sure to wait until the deployment has completed before continuing.  

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Helm 3
 ```
 helm install rabbitmq --set rabbitmq.username=user,rabbitmq.password=PASSWORD stable/rabbitmq
 ```
-⚠️ Some distributions of Kubernetes (like [Kind](https://kind.sigs.k8s.io/)) require that you add `volumePermissions.enabled=true` to the parameters in the `--set` option (e.g. `--set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true`)
+⚠️ Some distributions of Kubernetes (like [Kind](https://kind.sigs.k8s.io/)) require that you add `volumePermissions.enabled=true` to the parameters in the `--set` option:
+
+```--set rabbitmq.username=user,rabbitmq.password=PASSWORD,volumePermissions.enabled=true```
 
 
 ⚠️ Be sure to wait until the deployment has completed before continuing.  


### PR DESCRIPTION
The current installation instructions for RabbitMQ only cover Helm 3 syntax.  Additionally, the installation parameters for the RabbitMQ Helm chart won't work on certain Kubernetes distributions like Kind like don't support [using the Kubernetes Security Context to change the permissions of the persistent volume](https://github.com/helm/charts/issues/17250).