### PR TITLE
Update consumer to version 2 of Keda

### DIFF
--- a/deploy/deploy-consumer.yaml
+++ b/deploy/deploy-consumer.yaml
@@ -30,16 +30,14 @@ spec:
           args:
             - "amqp://user:PASSWORD@rabbitmq.default.svc.cluster.local:5672"
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
   name: rabbitmq-consumer
   namespace: default
-  labels:
-    deploymentName: rabbitmq-consumer
 spec:
   scaleTargetRef:
-    deploymentName: rabbitmq-consumer
+    name: rabbitmq-consumer
   pollingInterval: 5 # Optional. Default: 30 seconds
   cooldownPeriod: 30 # Optional. Default: 300 seconds
   maxReplicaCount: 30 # Optional. Default: 100
@@ -51,7 +49,7 @@ spec:
       authenticationRef:
         name: rabbitmq-consumer-trigger
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: rabbitmq-consumer-trigger


### PR DESCRIPTION
Using https://keda.sh/docs/2.0/migration/ I upgraded the consumer to work for version 2 of Keda.