### PR TITLE
update TriggerAuthentication apiversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ First you should clone the project:
 ```cli
 git clone https://github.com/kedacore/sample-go-rabbitmq
 cd sample-go-rabbitmq
+git checkout v2
 ```
 
 ### Creating a RabbitMQ queue

--- a/deploy/deploy-consumer.yaml
+++ b/deploy/deploy-consumer.yaml
@@ -49,7 +49,7 @@ spec:
       authenticationRef:
         name: rabbitmq-consumer-trigger
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: rabbitmq-consumer-trigger


### PR DESCRIPTION
When applying, I met the following error.

unable to recognize "deploy-consumer.yaml": no matches for kind "TriggerAuthentication" in version "keda.k8s.io/v1alpha1"

TriggerAuthentication apiVersion should use the latest version.