### PR TITLE
update TriggerAuthentication apiVersion

### DIFF
--- a/deploy/deploy-consumer.yaml
+++ b/deploy/deploy-consumer.yaml
@@ -49,7 +49,7 @@ spec:
       authenticationRef:
         name: rabbitmq-consumer-trigger
 ---
-apiVersion: keda.k8s.io/v1alpha1
+apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
 metadata:
   name: rabbitmq-consumer-trigger


### PR DESCRIPTION
Signed-off-by: xuqing <xq_dl@126.com>

When applying deploy-consumer.yaml, I met the following error.

unable to recognize "deploy-consumer.yaml": no matches for kind "TriggerAuthentication" in version "keda.k8s.io/v1alpha1"