### PR TITLE
Change the Golang AMQP repository

### DIFF
--- a/receive/go.mod
+++ b/receive/go.mod
@@ -2,4 +2,4 @@ module github.com/kedacore/sample-go-rabbitmq/receive
 
 go 1.18
 
-require github.com/streadway/amqp v1.0.0
+require github.com/rabbitmq/amqp091-go v1.3.4

--- a/receive/go.sum
+++ b/receive/go.sum
@@ -1,2 +1,2 @@
-github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
-github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/rabbitmq/amqp091-go v1.3.4 h1:tXuIslN1nhDqs2t6Jrz3BAoqvt4qIZzxvdbdcxWtHYU=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=

--- a/receive/receive.go
+++ b/receive/receive.go
@@ -4,8 +4,7 @@ import (
 	"log"
 	"os"
 	"time"
-
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {

--- a/send/go.mod
+++ b/send/go.mod
@@ -2,4 +2,4 @@ module github.com/kedacore/sample-go-rabbitmq/send
 
 go 1.18
 
-require github.com/streadway/amqp v1.0.0
+require github.com/rabbitmq/amqp091-go v1.3.4

--- a/send/go.sum
+++ b/send/go.sum
@@ -1,2 +1,2 @@
-github.com/streadway/amqp v1.0.0 h1:kuuDrUJFZL1QYL9hUNuCxNObNzB0bV/ZG5jV3RWAQgo=
-github.com/streadway/amqp v1.0.0/go.mod h1:AZpEONHx3DKn8O/DFsRAY58/XVQiIPMTMB1SddzLXVw=
+github.com/rabbitmq/amqp091-go v1.3.4 h1:tXuIslN1nhDqs2t6Jrz3BAoqvt4qIZzxvdbdcxWtHYU=
+github.com/rabbitmq/amqp091-go v1.3.4/go.mod h1:ogQDLSOACsLPsIq0NpbtiifNZi2YOz0VTJ0kHRghqbM=

--- a/send/send.go
+++ b/send/send.go
@@ -5,8 +5,7 @@ import (
 	"log"
 	"os"
 	"strconv"
-
-	"github.com/streadway/amqp"
+	amqp "github.com/rabbitmq/amqp091-go"
 )
 
 func failOnError(err error, msg string) {


### PR DESCRIPTION
The repo streadway/amqp is not maintened anymore.
The RabbitMQ team now maintain: https://github.com/rabbitmq/amqp091-go

Signed-off-by: Gabriele Santomaggio <G.santomaggio@gmail.com>

<!-- Thank you for contributing!

     Read more about how you can contribute in our contribution guide:
     https://github.com/kedacore/keda/blob/master/CONTRIBUTING.md
-->

_Provide a description of what has been changed_

### Checklist

- [x] Commits are signed with Developer Certificate of Origin (DCO)
- [ ] A PR is opened to update the documentation on [our docs repo](https://github.com/kedacore/keda-docs)

Fixes #
